### PR TITLE
feat: 添加获取图书借阅信息的测试 fixbug & refactor 部分代码修改 (dotnet)

### DIFF
--- a/dotnet/SpiderEngine.Test/ApiTest/Basic.cs
+++ b/dotnet/SpiderEngine.Test/ApiTest/Basic.cs
@@ -61,7 +61,8 @@
                 Engine = new EngineOptions
                 {
                     Cookie = true,
-                    Redirect = true
+                    Redirect = true,
+                    ForceSSL = true
                 },
                 Environment = ["baseUrl", "code"],
                 Task = new[]

--- a/dotnet/SpiderEngine.Test/CasTest/CasLogin.cs
+++ b/dotnet/SpiderEngine.Test/CasTest/CasLogin.cs
@@ -72,4 +72,31 @@ public class CasLogin
         var grades = JsonSerializer.Deserialize<ZhlgdGrade[]>(output3["grade_list"]);
         Assert.NotEmpty(grades!);
     }
+
+    [Fact]
+    public void LoginAndGetLibraryInfo()
+    {
+        var env = new Dictionary<string, string>();
+        var spiderGetPubkey = _spider.ReadCaseFromFile(Config.CasCasePath("library/ias_get_public_key"));
+        var client = _spider.CreateClient(spiderGetPubkey);
+        var output1 = _spider.Run(spiderGetPubkey, env, client);
+        var pubkey = output1["pubkey"];
+
+        Assert.NotEmpty(pubkey);
+
+        var rsa = RSA.Create();
+        rsa.ImportSubjectPublicKeyInfo(Convert.FromBase64String(pubkey), out _);
+
+        var ul = Convert.ToBase64String(rsa.Encrypt(Encoding.UTF8.GetBytes(Config.UserName), RSAEncryptionPadding.Pkcs1));
+        var pl = Convert.ToBase64String(rsa.Encrypt(Encoding.UTF8.GetBytes(Config.Password), RSAEncryptionPadding.Pkcs1));
+
+        var spiderLogin = _spider.ReadCaseFromFile(Config.CasCasePath("library/ias_library"));
+
+        env["ul"] = ul;
+        env["pl"] = pl;
+        env["redirect_url"] = UrlEncoder.Default.Encode("http://202.114.89.11/opac/special/toOpac");
+        var output2 = _spider.Run(spiderLogin, env, client);
+        Assert.NotNull(output2["lib_home"]);
+        Assert.NotEmpty(output2["lib_home"]);
+    }
 }

--- a/dotnet/SpiderEngine/Http/SpiderHttpClient.cs
+++ b/dotnet/SpiderEngine/Http/SpiderHttpClient.cs
@@ -12,6 +12,9 @@ internal class SpiderHttpClient : ISpiderHttpClient
         {
             AllowAutoRedirect = engineOptions.Redirect,
             UseCookies = engineOptions.Cookie,
+            ServerCertificateCustomValidationCallback = engineOptions.ForceSSL
+                ? (message, cert, chain, errors) => true // ignore SSL Check
+                : HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
         };
 
         this.client = new HttpClient(handler);
@@ -63,6 +66,10 @@ internal class SpiderHttpClient : ISpiderHttpClient
 
         var response = await this.client.SendAsync(message);
 
+        while(response.StatusCode == System.Net.HttpStatusCode.Redirect)
+        {
+            response = await this.client.GetAsync(response.Headers.Location);
+        }
         if ((int)response.StatusCode != success)
         {
             throw new HttpRequestException($"Request failed with status code {response.StatusCode}, expected {success}.");

--- a/dotnet/SpiderEngine/Model/EngineOptions.cs
+++ b/dotnet/SpiderEngine/Model/EngineOptions.cs
@@ -4,4 +4,5 @@ public class EngineOptions
 {
     public bool Cookie { get; set; }
     public bool Redirect { get; set; }
+    public bool ForceSSL { get; set; }
 }

--- a/dotnet/SpiderEngine/Parser/Content/RegexContentParser.cs
+++ b/dotnet/SpiderEngine/Parser/Content/RegexContentParser.cs
@@ -12,16 +12,26 @@ internal class RegexContentParser : IContentParser
 
     public void Parse(string content, string patten, IEnumerable<SpiderKeyPathPair> value)
     {
-        var match = Regex.Match(content, patten, RegexOptions.Singleline);
-        if (!match.Success)
-        {
-            throw new ParseException("Content does not match the patten.");
-        }
+        Regex.Match(content, patten);
+        var matches = Regex.Matches(content, patten, RegexOptions.Singleline).ToList();
+
         try
         {
+            var dict = matches
+                .Select(
+                    (match, index) =>
+                    {
+                        if (!match.Success)
+                        {
+                            throw new ParseException("Content does not match the patten.");
+                        }
+                        return (index, match.Groups.Values.First());
+                    }
+                )
+                .ToDictionary();
             foreach (var pair in value)
             {
-                Context[pair.Key] = match.Groups[int.Parse(pair.Path)].Value;
+                Context[pair.Key] = dict[int.Parse(pair.Path)].Value;
             }
         }
         catch (AggregateException ex)

--- a/test/cases/iwut/library/ias_get_public_key.json
+++ b/test/cases/iwut/library/ias_get_public_key.json
@@ -1,0 +1,32 @@
+{
+    "name": "ias_get_public_key",
+    "version": 1,
+    "engine": {
+        "cookie": true,
+        "redirect": true,
+        "forceSSL": false,
+        "delay": 100
+    },
+    "environment": [],
+    "task": [
+        {
+            "name": "get_public_key",
+            "url": "https://zhlgd.whut.edu.cn/tpass/rsa?skipWechat=true",
+            "method": "post",
+            "payload": null,
+            "success": 200,
+            "content": {
+                "type": "json",
+                "patten": "",
+                "value": [
+                    {
+                        "key": "pubkey",
+                        "path": "publicKey"
+                    }
+                ]
+            },
+            "header": []
+        }
+    ],
+    "output": ["pubkey"]
+}

--- a/test/cases/iwut/library/ias_library.json
+++ b/test/cases/iwut/library/ias_library.json
@@ -4,6 +4,7 @@
     "engine": {
         "cookie": true,
         "redirect": true,
+        "forceSSL": false,
         "delay": 500
     },
     "environment": ["ul", "pl", "redirect_url"],
@@ -15,11 +16,15 @@
             "success": 200,
             "content": {
                 "type": "regex",
-                "patten": "(LT-\\d+-.+?-tpass)",
+                "patten": "(LT-\\d+-.+?-tpass|e\\d{1}s\\d{1})",
                 "value": [
                     {
                         "key": "lt",
                         "path": "0"
+                    },
+                    {
+                        "key": "execution",
+                        "path": "1"
                     }
                 ]
             },
@@ -52,7 +57,7 @@
                     },
                     {
                         "key": "execution",
-                        "value": "e1s1",
+                        "value": "$(execution)",
                         "type": "string"
                     },
                     {
@@ -133,24 +138,18 @@
                         "type": "string"
                     }
                 ]
-            }
-        },
-        {
-            "name": "zhlgd_home",
-            "url": "https://zhlgd.whut.edu.cn/tp_up/view?m=up",
-            "method": "get",
-            "success": 200,
+            },
             "content": {
                 "type": "regex",
                 "patten": "^.+$",
                 "value": [
                     {
-                        "key": "zhlgd_home",
+                        "key": "lib_home",
                         "path": "0"
                     }
                 ]
             }
         }
     ],
-    "output": ["zhlgd_home"]
+    "output": ["lib_home"]
 }


### PR DESCRIPTION
feat: 添加获取图书借阅信息的测试 feat: engineOption 新增forceSSL属性 fixbug: 修复post请求时可能的302不跳转 refactor: 重构Regex解析部分，现在path的含义是匹配到的所有值的index